### PR TITLE
Gradient Accumulation

### DIFF
--- a/yolo/config/config.py
+++ b/yolo/config/config.py
@@ -60,6 +60,7 @@ class DataConfig:
     data_augment: Dict[str, int]
     source: Optional[Union[str, int]]
     dynamic_shape: Optional[bool]
+    nominal_batch_size: Optional[int] = None
 
 
 @dataclass

--- a/yolo/config/task/train.yaml
+++ b/yolo/config/task/train.yaml
@@ -7,6 +7,7 @@ epoch: 500
 
 data:
   batch_size: 16
+  nominal_batch_size: 128
   image_size: ${image_size}
   cpu_num: ${cpu_num}
   shuffle: True
@@ -23,7 +24,7 @@ data:
 optimizer:
   type: SGD
   args:
-    lr: 0.0005
+    lr: 0.008
     weight_decay: 0.0005
     momentum: 0.937
     nesterov: true

--- a/yolo/lazy.py
+++ b/yolo/lazy.py
@@ -35,6 +35,28 @@ def main(cfg: Config):
 
     callbacks, loggers, save_path = setup(cfg, early_stopping_patience=early_stopping_patience)
 
+    # Gradient accumulation: keep the effective (nominal) batch size constant
+    # regardless of available GPU memory. The per-step physical batch may be
+    # smaller than the paper's batch size; we accumulate gradients across
+    # grad_accum_steps forward/backward passes to recover the same update.
+    accumulate_grad_batches = 1
+    if cfg.task.task == 'train':
+        world_size = int(os.environ.get('WORLD_SIZE', '1'))
+        batch_size = cfg.task.data.batch_size
+        nominal_batch_size = getattr(cfg.task.data, 'nominal_batch_size', None) or batch_size
+        total_step_batch = batch_size * world_size
+        if nominal_batch_size % total_step_batch != 0:
+            print(
+                f"Warning: nominal_batch_size ({nominal_batch_size}) is not divisible by "
+                f"batch_size * world_size ({total_step_batch}); effective batch size will be "
+                f"{(nominal_batch_size // total_step_batch) * total_step_batch}"
+            )
+        accumulate_grad_batches = max(1, nominal_batch_size // total_step_batch)
+        print(
+            f"Gradient accumulation: physical batch={batch_size}, world_size={world_size}, "
+            f"nominal batch={nominal_batch_size}, accumulate_grad_batches={accumulate_grad_batches}"
+        )
+
     trainer = Trainer(
         accelerator='auto',
         max_epochs=epochs,
@@ -47,6 +69,7 @@ def main(cfg: Config):
         enable_progress_bar=False,
         default_root_dir=save_path,
         limit_val_batches=5000 // val_batch_size,
+        accumulate_grad_batches=accumulate_grad_batches,
     )
 
     if cfg.task.task == 'train':

--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -100,7 +100,11 @@ class TrainModel(ValidateModel):
             rank_zero_only=True,
         )
         self.log_dict(lr_dict, prog_bar=False, logger=True, on_epoch=False, rank_zero_only=True)
-        return loss * batch_size
+        # Divide by accumulation steps so that the summed gradient across
+        # grad_accum_steps physical batches equals the mean gradient over the
+        # nominal batch. Combined with Trainer(accumulate_grad_batches=N), this
+        # keeps the effective update magnitude independent of physical batch size.
+        return loss / self.trainer.accumulate_grad_batches
 
     def configure_optimizers(self):
         optimizer = create_optimizer(self.model, self.cfg.task.optimizer)


### PR DESCRIPTION
Enables batch gradient accumulation. This allows us to operate at low batch sizes (e.g., 16), but accumulate them into larger effective batch sizes (128).