### PR TITLE
Update val_batch_size

### DIFF
--- a/yolo/lazy.py
+++ b/yolo/lazy.py
@@ -31,6 +31,7 @@ def main(cfg: Config):
 
     early_stopping_patience = getattr(cfg.task, 'early_stopping_patience', None)
     epochs = getattr(cfg.task, 'epoch', None)
+    min_epochs = getattr(cfg.task, 'min_epochs', None)
     val_batch_size = getattr(getattr(cfg.task, 'validation', cfg.task).data, 'batch_size', 32)
 
     callbacks, loggers, save_path = setup(cfg, early_stopping_patience=early_stopping_patience)
@@ -60,6 +61,7 @@ def main(cfg: Config):
     trainer = Trainer(
         accelerator='auto',
         max_epochs=epochs,
+        min_epochs=min_epochs,
         precision='16-mixed',
         logger=loggers,
         callbacks=callbacks,
@@ -68,7 +70,7 @@ def main(cfg: Config):
         deterministic=False,
         enable_progress_bar=False,
         default_root_dir=save_path,
-        limit_val_batches=5000 // val_batch_size,
+        limit_val_batches=1.0,
         accumulate_grad_batches=accumulate_grad_batches,
     )
 

--- a/yolo/utils/logging_utils.py
+++ b/yolo/utils/logging_utils.py
@@ -279,7 +279,7 @@ def setup(cfg: Config, early_stopping_patience: Optional[int]=None):
     if early_stopping_patience is None:
         early_stopping_patience = 5
 
-    progress.append(EarlyStopping('map', mode='max', patience=early_stopping_patience))
+    progress.append(EarlyStopping('map', mode='max', patience=early_stopping_patience, min_delta=0.001))
     progress.append(EpochLogger())
     progress.append(ModelCheckpoint(monitor='map', mode='max', save_top_k=1, filename='best'))
 


### PR DESCRIPTION
Change val_batch_size from 5000 to 1.0 - meaning, use all val data to compute val loss. adding min_delta and min_epochs variables.

## Changes

  ### 1. Run validation on the full val set each epoch — `yolo/lazy.py`

  ```diff
  - limit_val_batches=5000 // val_batch_size,
  + limit_val_batches=1.0,

  Removes the implicit random subsampling. Validation now evaluates every val image every epoch, giving the early-stop callback a stable, comparable signal across epochs. Per-epoch val time increases roughly 3× on a 15k-image val set, but the run terminates correctly instead of being cut short — net wall-clock is lower in practice.

  2. Add min_delta=0.001 to EarlyStopping — yolo/utils/logging_utils.py

  - progress.append(EarlyStopping('map', mode='max', patience=early_stopping_patience))
  + progress.append(EarlyStopping('map', mode='max', patience=early_stopping_patience, min_delta=0.001))

  Requires an actual improvement of at least 0.001 mAP to reset the patience counter. Belt-and-suspenders alongside the val change above — protects against any residual floating-point noise and tiny non-meaningful regressions. Matches the pattern already used by the D-FINE pipeline (which uses 0.003; we chose tighter here since fine-tunes can land in tighter local minima).

  3. Support a min_epochs floor — yolo/lazy.py

  + min_epochs = getattr(cfg.task, 'min_epochs', None)
  
    trainer = Trainer(
        accelerator='auto',
        max_epochs=epochs,
  +     min_epochs=min_epochs,
        ...
    )

  Reads an optional cfg.task.min_epochs and passes it to Lightning's Trainer. When set, Lightning will not terminate before the given epoch regardless of what EarlyStopping says.

  Decouples "minimum training runway" from "patience" — previously the two were tangled (lowering patience also lowered the soft floor on epochs). Now min_epochs can be tuned independently from the Go side via +task.min_epochs=N.

  Defaults to None (no floor) when not provided, so this is a backward-compatible additive change for any caller that doesn't set it.